### PR TITLE
feat(ui): unify exercise card heights and show full thumbnails

### DIFF
--- a/src/components/exercise/ExerciseCard.tsx
+++ b/src/components/exercise/ExerciseCard.tsx
@@ -3,6 +3,7 @@ import type { Exercise } from '@/types/index'; // 타입 경로는 실제 프로
 import { Card } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { HiOutlineHeart, HiHeart, HiPlus } from 'react-icons/hi';
+import { Link } from 'react-router-dom';
 
 interface ExerciseCardProps {
   exercise: Exercise;
@@ -13,40 +14,43 @@ interface ExerciseCardProps {
 
 const ExerciseCard: React.FC<ExerciseCardProps> = ({ exercise, isLiked, onLikeToggle, onAddToRoutine }) => {
   return (
-    <Card className="flex flex-col">
-      {/* 썸네일 이미지 */}
-      <div className="relative w-full h-40 bg-gray-200">
-        {exercise.thumbnailUrl ? (
-          <img 
-            src={exercise.thumbnailUrl} 
-            alt={`${exercise.name} thumbnail`}
-            className="w-full h-full object-cover" 
-          />
-        ) : (
-          <div className="w-full h-full flex items-center justify-center bg-blue-500">
-            <h3 className="text-white text-2xl font-bold px-2 text-center">{exercise.name}</h3>
-          </div>
-        )}
-      </div>
-      {/* 운동 정보 */}
-      <div className="p-4 flex-grow">
-        <p className="font-bold text-lg">{exercise.name}</p>
-        <p className="text-sm text-gray-500">{exercise.bodyPart} / {exercise.posture}</p>
-      </div>
-      {/* 버튼 영역 */}
-      <div className="p-4 border-t flex justify-end items-center space-x-2">
-        <button onClick={onLikeToggle} className="text-gray-400 hover:text-red-500">
-          {isLiked ? (
-            <HiHeart className="w-6 h-6 text-red-500" />
+    <Link to={`/exercises/${exercise.id}`} className="block h-full">
+      <Card className="flex flex-col h-full">
+        {/* 썸네일 이미지 */}
+        <div className="relative w-full h-40 bg-gray-200">
+          {exercise.thumbnailUrl ? (
+            <img 
+              src={exercise.thumbnailUrl} 
+              alt={`${exercise.name} thumbnail`}
+              className="w-full h-full object-contain bg-white"
+              loading="lazy"
+            />
           ) : (
-            <HiOutlineHeart className="w-6 h-6" />
+            <div className="w-full h-full flex items-center justify-center bg-blue-500">
+              <h3 className="text-white text-2xl font-bold px-2 text-center">{exercise.name}</h3>
+            </div>
           )}
-        </button>
-        <Button onClick={onAddToRoutine} size="icon" variant="outline" className="rounded-full w-8 h-8">
-          <HiPlus className="w-5 h-5" />
-        </Button>
-      </div>
-    </Card>
+        </div>
+        {/* 운동 정보 */}
+        <div className="p-4 flex-grow min-h-[48px]">
+          <p className="font-bold text-lg">{exercise.name}</p>
+          <p className="text-sm text-gray-500">{exercise.bodyPart} / {exercise.posture}</p>
+        </div>
+        {/* 버튼 영역 */}
+        <div className="p-4 border-t flex justify-end items-center space-x-2">
+          <button onClick={onLikeToggle} className="text-gray-400 hover:text-red-500">
+            {isLiked ? (
+              <HiHeart className="w-6 h-6 text-red-500" />
+            ) : (
+              <HiOutlineHeart className="w-6 h-6" />
+            )}
+          </button>
+          <Button onClick={onAddToRoutine} size="icon" variant="outline" className="rounded-full w-8 h-8">
+            <HiPlus className="w-5 h-5" />
+          </Button>
+        </div>
+      </Card>
+    </Link>
   );
 };
 

--- a/src/components/exercise/ExerciseGrid.tsx
+++ b/src/components/exercise/ExerciseGrid.tsx
@@ -13,7 +13,6 @@ interface ExerciseGridProps {
 const ExerciseGrid: React.FC<ExerciseGridProps> = ({
   exercises, likedExerciseIds, onLikeToggle, onAddToRoutine,
 }) => {
-
   // 버튼 클릭 시 링크 이동을 막는 핸들러
   const handleAddToRoutineClick = (e: React.MouseEvent, exercise: Exercise) => {
     e.preventDefault();
@@ -26,16 +25,15 @@ const ExerciseGrid: React.FC<ExerciseGridProps> = ({
   };
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 items-stretch">
       {exercises.map((exercise) => (
-        <Link to={`/exercises/${exercise.id}`} key={exercise.id} className="block">
-          <ExerciseCard
-            exercise={exercise}
-            isLiked={likedExerciseIds.has(exercise.id)}
-            onLikeToggle={(e) => handleLikeToggleClick(e, exercise.id)}
-            onAddToRoutine={(e) => handleAddToRoutineClick(e, exercise)}
-          />
-        </Link>
+        <ExerciseCard
+          key={exercise.id}
+          exercise={exercise}
+          isLiked={likedExerciseIds.has(exercise.id)}
+          onLikeToggle={(e) => handleLikeToggleClick(e, exercise.id)}
+          onAddToRoutine={(e) => handleAddToRoutineClick(e, exercise)}
+        />
       ))}
     </div>
   );


### PR DESCRIPTION
- Add items-stretch to ExerciseGrid for consistent card heights
- Apply h-full to Card and wrap entire card with Link for full clickable area
- Use object-contain and bg-white for thumbnails to display full image with white background
- Add min-h to text area to minimize card height shifts