### PR TITLE
feat: support admin redirect and UI for admin users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,6 @@ const App = () => {
         <Route path="/community/:id" element={<CommunityDetailPage />} />
         <Route path="/community/write" element={<CommunityWritePage />} />
         <Route path="/community/edit/:id" element={<CommunityWritePage />} />
-        <Route path="/" element={<Navigate to="/admin" />} />
         <Route path="/admin" element={<DashboardPage />} />
         <Route path="/admin/members" element={<MemberManagementPage />} />
         <Route path="/admin/post" element={<ContentManagementPage />} />

--- a/src/components/common/AdminLayout.tsx
+++ b/src/components/common/AdminLayout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
-import { Menu, BarChart, Users, FileText } from 'lucide-react';
+import { Menu, BarChart, Users, FileText, Home } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 // Props 타입 정의
@@ -21,6 +21,7 @@ const navLinks: NavLinkInfo[] = [
   { href: "/admin", label: "대시보드", icon: BarChart },
   { href: "/admin/members", label: "회원 관리", icon: Users },
   { href: "/admin/post", label: "콘텐츠 관리", icon: FileText },
+  { href: "/", label: "사용자 화면", icon: Home }, // 사용자 화면 이동 메뉴 추가
 ];
 
 // 사이드바 컴포넌트

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -99,6 +99,15 @@ const Header: React.FC = () => {
           </button>
           {user ? (
             <>
+              {user.role === 'ADMIN' && (
+                <Button
+                  className="bg-gray-100 text-black hover:bg-gray-200 cursor-pointer"
+                  onClick={() => navigate('/admin')}
+                  style={{ cursor: 'pointer' }}
+                >
+                  관리자 페이지
+                </Button>
+              )}
               <Button
                 className="bg-gray-100 text-blue-600 hover:bg-gray-200 cursor-pointer"
                 onClick={() => navigate("/mypage")}
@@ -161,6 +170,15 @@ const Header: React.FC = () => {
         <div className="flex flex-col gap-2 mt-6 border-t pt-4">
           {user ? (
             <>
+              {user.role === 'ADMIN' && (
+                <Button
+                  className="bg-yellow-500 text-white hover:bg-yellow-600 w-full cursor-pointer mb-2"
+                  onClick={() => handleMenuClick('/admin')}
+                  style={{ cursor: 'pointer' }}
+                >
+                  관리자 페이지
+                </Button>
+              )}
               <Button
                 className="bg-gray-100 text-blue-600 hover:bg-gray-200 w-full cursor-pointer"
                 onClick={() => handleMenuClick("/mypage")}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -35,8 +35,9 @@ const LoginPage = () => {
           user: {
             id: responseData.user.id,
             name: responseData.user.name,
-            goal: '', // Default empty goal for regular login
-            profileImageUrl: null // Default null profile image for regular login
+            role: responseData.user.role,
+            goal: '',
+            profileImageUrl: null
           },
           token: responseData.token,
           success: responseData.success,
@@ -46,7 +47,9 @@ const LoginPage = () => {
         
         loginUser(loginResponse);
         
-        navigate(from);
+        // role이 ADMIN이면 admin 페이지로, 아니면 원래 목적지로 이동
+        const targetPath = responseData.user.role === 'ADMIN' ? '/admin' : from;
+        navigate(targetPath);
         alert(`🎉 로그인 성공!\n환영합니다, ${responseData.user.name}님!`);
       } else {
         alert(`❌ 로그인 실패: ${responseData.message}`);

--- a/src/pages/OAuth2RedirectHandler.tsx
+++ b/src/pages/OAuth2RedirectHandler.tsx
@@ -33,7 +33,10 @@ const OAuth2RedirectHandler = () => {
                     };
                     
                     loginUser(loginResponse);
-                    navigate('/dashboard');
+                    
+                    // role이 ADMIN이면 admin 페이지로, 아니면 dashboard로 이동
+                    const targetPath = user.role === 'ADMIN' ? '/admin' : '/dashboard';
+                    navigate(targetPath);
                 })
                 .catch((error) => {
                     console.error("유저 정보 가져오기 실패:", error);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@ export interface User {
     id: number; 
     name: string;
     goal: string;
+    role?: 'MEMBER' | 'ADMIN';
     profileImageUrl: string | null;
 }
 


### PR DESCRIPTION
- Redirect users with admin role to /admin after login
- Unify User type to include role, goal, and profileImageUrl fields
- Add "User View" link to admin sidebar
- Show "Admin Page" button in header for admin users