### PR TITLE
feat: Implement full analysis flow and enhance result page

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,8 +1,8 @@
 import axios from 'axios';
 
 const axiosInstance = axios.create({
-  baseURL: 'http://192.168.2.6:8081/api',
-  timeout: 10000,
+  baseURL: 'http://localhost:8081/api',
+  timeout: 30000,
   headers: {
     'Content-Type': 'application/json',
   },

--- a/src/pages/AnalysisSharePage.tsx
+++ b/src/pages/AnalysisSharePage.tsx
@@ -71,7 +71,15 @@ const AnalysisSharePage: React.FC = () => {
         <Card className="p-6 mb-6">
           <h2 className="font-bold text-lg mb-4">Keypoint 분석</h2>
           <div className="h-64 bg-muted rounded-md flex items-center justify-center">
-            <p className="text-gray-500">분석 이미지 표시 영역</p>
+            {analysis.radarChartUrl ? (
+              <img
+                src={analysis.radarChartUrl}
+                alt="자세 분석 레이더 차트"
+                className="max-h-60 max-w-full object-contain"
+              />
+            ) : (
+              <p className="text-gray-500">분석 이미지 표시 영역</p>
+            )}
           </div>
         </Card>
         {/* 부위별 진단 카드 */}

--- a/src/services/api/analysisApi.ts
+++ b/src/services/api/analysisApi.ts
@@ -5,3 +5,23 @@ export const fetchAnalysisDetail = async (analysisId: number): Promise<AnalysisH
   const res = await axiosInstance.get(`/analysis-histories/${analysisId}`);
   return res.data;
 }; 
+
+/**
+ * Cloudinary URL을 이용해 분석을 요청합니다.
+ * @param userId 사용자 ID
+ * @param imageUrl Cloudinary 이미지 URL
+ * @param mode 분석 모드 (예: 'front', 'side')
+ * @returns 분석 결과 DTO
+ */
+export const requestAnalysis = async (
+  userId: number,
+  imageUrl: string,
+  mode: string
+): Promise<AnalysisHistoryItem> => {
+  console.log('requestAnalysis 호출됨', userId, imageUrl, mode);
+  const res = await axiosInstance.post(`/analysis-histories/user/${userId}`, {
+    imageUrl,
+    mode
+  });
+  return res.data;
+}; 

--- a/src/services/api/cloudinaryApi.ts
+++ b/src/services/api/cloudinaryApi.ts
@@ -1,0 +1,15 @@
+import axiosInstance from '@/api/axiosInstance';
+
+/**
+ * Cloudinary에 이미지를 업로드하고 업로드된 이미지의 URL을 반환합니다.
+ * @param file 업로드할 이미지 파일
+ * @returns 업로드된 이미지의 Cloudinary URL
+ */
+export const uploadToCloudinary = async (file: File): Promise<string> => {
+  const formData = new FormData();
+  formData.append('file', file);
+  const response = await axiosInstance.post('/cloudinary/upload', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' }
+  });
+  return response.data;
+}; 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,8 +59,14 @@ export interface AnalysisHistoryItem {
   pelvicScore: number;
   neckScore: number;
   shoulderScore: number;
+  // 추가: 진단, 차트, 이미지 등
+  diagnosis?: string;
+  radarChartUrl?: string;
+  frontImageUrl?: string;
+  sideImageUrl?: string;
+  feedback?: Record<string, any>;
+  measurements?: Record<string, any>;
 }
-
 export interface ExerciseLog {
   // Response용 필드
   id?: number;


### PR DESCRIPTION
사진 업로드부터 분석 결과 확인까지의 전체 사용자 플로우를 구현하고, 결과 페이지의 UI/UX 개선

- PhotoUpload
  - 사용자가 사진을 업로드하면 Cloudinary에 저장
  - 반환된 URL로 자세 분석을 요청
  - 분석 완료 후 결과 페이지로 이동
 
- API 서비스 분리
  - Cloudinary 업로드(`cloudinaryApi.ts`)와 자세 분석 요청(`analysisApi.ts`) API를 모듈화
 
- 결과 페이지
  - `AnalysisResultPage`가 URL의 ID를 기반으로 분석 결과를 서버에서 직접 조회하도록 변경하여, 페이지 공유 및 새로고침 기능 지원

- UI/UX 개선:
    - 점수, 텍스트 피드백, 구체적인 측정값(각도 등)을 포함한 상세 진단 결과 표시
    - '우수', '보통', '주의', '위험'의 4단계 등급 시스템을 도입하여 직관적인 피드백 제공
    - 가독성 향상을 위해 레이아웃 정렬을 개선하고 레이더 차트 크기를 확대
    - 분석 요청 버튼에 로딩 커서를 추가하여 사용자 경험을 개선
  
- 버그 수정:
    - AI 분석에 시간이 걸리는 경우를 대비해 Axios 타임아웃 시간을 늘려 요청 실패 방지