### PR TITLE
feat: Add analysis history delete & robust loading UX for analysis flow

### DIFF
--- a/src/pages/AnalysisSharePage.tsx
+++ b/src/pages/AnalysisSharePage.tsx
@@ -55,7 +55,7 @@ const AnalysisSharePage: React.FC = () => {
   const measurements = analysis.measurements || {};
 
   const diagnoses = [
-    { part: "목목", score: analysis.neckScore, feedback: feedback.head_forward || feedback.neck_error, measurement: measurements.neck_forward_angle, unit: "°" },
+    { part: "목", score: analysis.neckScore, feedback: feedback.head_forward || feedback.neck_error, measurement: measurements.neck_forward_angle, unit: "°" },
     { part: "어깨", score: analysis.shoulderScore, feedback: feedback.shoulder_tilt, measurement: measurements.shoulder_tilt_angle, unit: "°" },
     { part: "척추(정면)", score: analysis.spineScolScore, feedback: feedback.torso_tilt, measurement: measurements.torso_tilt_angle, unit: "°" },
     { part: "척추(측면)", score: analysis.spineCurvScore, feedback: feedback.back_bend, measurement: measurements.back_angle, unit: "°" },

--- a/src/services/api/analysisApi.ts
+++ b/src/services/api/analysisApi.ts
@@ -66,3 +66,11 @@ export const requestMergedAnalysis = async (
   });
   return res.data;
 };
+
+/**
+ * 분석 기록을 삭제합니다.
+ * @param analysisId - 삭제할 분석 기록 ID
+ */
+export const deleteAnalysisHistory = async (analysisId: number): Promise<void> => {
+  await axiosInstance.delete(`/analysis-histories/${analysisId}`);
+};


### PR DESCRIPTION
- 마이페이지 분석 기록(AnalysisHistory) 삭제 기능 프론트/백엔드 연동 구현
  - 프론트엔드에 삭제 버튼 및 삭제 API 연동, 삭제 후 목록 즉시 갱신
  - 백엔드 REST API(DELETE)와 연동
- 분석 결과 페이지(AnalysisResultPage) 로딩 상태 관리 개선
  - status 대신 loading 상태 단일 관리로 리팩토링
  - 로딩 상태 변화 콘솔 로그 추가로 디버깅 용이
  - 다크모드에서 주요 텍스트(점수, 각도, AI 소견) 가독성 개선
- 사진 업로드/분석(Cloudinary 업로드 및 분석 요청) 중 로딩 UI 추가
  - 업로드 및 분석 요청 중에는 중앙에 스피너와 메시지로 로딩 상태 명확히 표시
  - 최소 1초 이상 로딩 보장으로 사용자 경험 개선
- ExerciseListPage의 추천 로딩 구조를 참고하여 일관된 UX 적용