### PR TITLE
feat: Add workout recommendation feature and improve chatbot UX

### DIFF
--- a/src/pages/AnalysisResultPage.tsx
+++ b/src/pages/AnalysisResultPage.tsx
@@ -422,6 +422,7 @@ const AnalysisResultPage: React.FC<AnalysisResultPageProps> = ({ isReadOnly = fa
             initPayload={chatInitPayload}
             initialUserMessage={initialUserMessage}
             initialVideoUrl={initialVideoUrl}
+            analysis={analysis} // analysis 객체 전달
           />
         )}
       </div>

--- a/src/pages/RoutineDetailPage.tsx
+++ b/src/pages/RoutineDetailPage.tsx
@@ -46,9 +46,14 @@ const RoutineDetailPage: React.FC = () => {
         style={{ paddingTop: 'var(--header-height, 90px)' }}
       >
         <div className="flex justify-between items-center mb-6">
-          <Button variant="outline" onClick={() => navigate(-1)}>
-            <ArrowLeft className="mr-2 h-4 w-4" /> 뒤로가기
-          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => navigate(-1)}>
+              <ArrowLeft className="mr-2 h-4 w-4" /> 뒤로가기
+            </Button>
+            <Button variant="outline" onClick={() => navigate('/mypage')}>
+              목록으로
+            </Button>
+          </div>
           <Button 
           className="bg-blue-600 hover:bg-blue-700 text-white"
           onClick={() => navigate(`/routines/edit/${routine.id}`)}>

--- a/src/services/api/chatbotApi.ts
+++ b/src/services/api/chatbotApi.ts
@@ -8,6 +8,7 @@ export interface ChatRequestDTO {
   message?: string;
   content?: string;
   videoUrl?: string;
+  recommendedExercise?: Record<string, any>; // 추가
 }
 
 export interface ChatResponseDTO {
@@ -65,41 +66,21 @@ export const getChatHistory = async (userId: number): Promise<ChatMessageDTO[]> 
 };
 
 /**
- * 특정 세션의 대화 기록을 조회합니다.
- * @param userId - 사용자 ID
- * @param sessionId - 세션 ID
- */
-export const getChatHistoryBySession = async (userId: number, sessionId: string): Promise<ChatMessageDTO[]> => {
-  try {
-    const response = await axiosInstance.get(`/chatbot/history/${userId}/${sessionId}`);
-    return response.data || [];
-  } catch (error) {
-    throw new Error('특정 세션 대화 기록 조회에 실패했습니다.');
-  }
-};
-
-/**
  * AI코치/운동추천 메시지를 전송합니다. (FastAPI /ai-coach)
  * @param request - 메시지 전송 요청 데이터
  */
-export const sendAiCoachMessage = async (request: ChatRequestDTO): Promise<ChatResponseDTO> => {
-  try {
-    const response = await axiosInstance.post('/chatbot/send', request);
-    return response.data;
-  } catch (error) {
-    throw new Error('AI코치 메시지 전송에 실패했습니다.');
-  }
+export const sendAiCoachMessage = async (payload: ChatRequestDTO): Promise<ChatResponseDTO> => {
+  const res = await axiosInstance.post('/chatbot/send', payload);
+  console.log('[DEBUG] 프론트엔드에서 받은 AI 코치 응답:', res.data);
+  return res.data;
 };
 
 /**
  * 유튜브(영상추천/스크립트/댓글요약) 메시지를 전송합니다. (FastAPI /youtube)
  * @param request - 메시지 전송 요청 데이터 (type 필수)
  */
-export const sendYoutubeMessage = async (request: ChatRequestDTO): Promise<ChatResponseDTO> => {
-  try {
-    const response = await axiosInstance.post('/chatbot/send', request);
-    return response.data;
-  } catch (error) {
-    throw new Error('유튜브 메시지 전송에 실패했습니다.');
-  }
+export const sendYoutubeMessage = async (payload: ChatRequestDTO): Promise<ChatResponseDTO> => {
+  const res = await axiosInstance.post('/chatbot/send', payload);
+  console.log('[DEBUG] 프론트엔드에서 받은 Youtube 응답:', res.data);
+  return res.data;
 }; 

--- a/src/services/api/exerciseApi.ts
+++ b/src/services/api/exerciseApi.ts
@@ -147,6 +147,23 @@ export const fetchPopularExercisesByRoutineAdditions = async (limit: number = 5)
   }
 };
 
+/**
+ * 정확히 일치하는 운동명으로 운동을 조회합니다.
+ * @param name - 운동명
+ * @returns {Promise<Exercise|null>} 운동 객체 또는 null(없을 때)
+ */
+export const fetchExerciseByExactName = async (name: string): Promise<Exercise | null> => {
+  try {
+    const response = await axiosInstance.get(`/exercises/search/exact`, { params: { name } });
+    return response.data;
+  } catch (error: any) {
+    if (error.response && error.response.status === 404) {
+      return null;
+    }
+    throw new Error('정확히 일치하는 운동명을 조회하는 데 실패했습니다.');
+  }
+};
+
 // AI 운동 추천을 요청하는 API 함수
 export const fetchExerciseRecommendations = async (
   payload: RecommendationPayload

--- a/src/services/api/routineApi.ts
+++ b/src/services/api/routineApi.ts
@@ -1,5 +1,6 @@
 import type { Routine } from '@/types/index';
 import axiosInstance from '../../api/axiosInstance';
+import type { RoutineExercise } from '@/types/index';
 
 /**
  * 새로운 루틴을 생성합니다.
@@ -96,4 +97,37 @@ export const getRoutinesByUser = async (userId: number): Promise<Routine[]> => {
   } catch (error) {
     throw new Error('루틴 목록을 불러오는 데 실패했습니다.');
   }
+};
+
+export interface CreateRoutineWithExerciseRequest {
+  routineDTO: {
+    name: string;
+    description?: string;
+  };
+  exerciseId: number;
+  order: number;
+}
+
+/**
+ * 챗봇: 신규 루틴 생성 + 운동 추가 (트랜잭션)
+ * @param userId - 사용자 ID
+ * @param req - routineDTO, exerciseId, order
+ * @returns 생성된 루틴 전체 정보
+ */
+export const createRoutineWithExercise = async (
+  userId: number,
+  req: CreateRoutineWithExerciseRequest
+): Promise<Routine> => {
+  const response = await axiosInstance.post(`/routines/user/${userId}/with-exercise`, req);
+  return response.data;
+};
+
+/**
+ * 특정 루틴의 운동 목록을 조회합니다.
+ * @param routineId - 루틴 ID
+ * @returns 루틴에 포함된 운동 목록
+ */
+export const fetchExercisesInRoutine = async (routineId: number): Promise<RoutineExercise[]> => {
+  const response = await axiosInstance.get(`/routines/${routineId}/exercises`);
+  return response.data;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -66,6 +66,8 @@ export interface AnalysisHistoryItem {
   sideImageUrl?: string;
   feedback?: Record<string, any>;
   measurements?: Record<string, any>;
+  recommendedExercise?: Record<string, any>;
+
 }
 export interface ExerciseLog {
   // Response용 필드


### PR DESCRIPTION
- ChatModal에서 신규/기존 루틴에 추천운동 추가 시, 해당 루틴 상세페이지로 이동하도록 구현
- 기존 루틴에 운동 추가 시, 이미 포함된 운동이면 중복 알림 후 추가 방지

  - ChatModal.tsx : 신규 루틴/기존 루틴에 추천 운동 추가 버튼
  - AnalysisResultPage.tsx: analysis 전달 
  - RoutineDetailPage.tsx: 루틴 상세페이지에서 마이페이지로 가는 버튼 추가
  - chatbotApi.ts: ChatRequestDTO에 recommendedExercise 추가
  - exerciseApi.ts: 운동명 정확히 일치하는 운동 id 조회
  - routinApi.ts : 신규 루틴 생성 + 운동 추가, 특정 루틴의 운동 목록 조회
  - index.ts: AnalysisHistoryItem에 recommnededExercise 추가
